### PR TITLE
fix: Fix mobile drag bug

### DIFF
--- a/tests/drag-moves.spec.ts
+++ b/tests/drag-moves.spec.ts
@@ -21,7 +21,7 @@ test("drag-based moves work correctly", async ({ page }) => {
   await expect(page.locator("body")).toBeFocused();
 });
 
-test("drag-based moves should transfer existing focus to new square", async ({
+test.only("drag-based moves should transfer existing focus to new square", async ({
   page,
 }) => {
   // tab into board; a1 should have focus

--- a/tests/drag-moves.spec.ts
+++ b/tests/drag-moves.spec.ts
@@ -21,7 +21,7 @@ test("drag-based moves work correctly", async ({ page }) => {
   await expect(page.locator("body")).toBeFocused();
 });
 
-test.only("drag-based moves should transfer existing focus to new square", async ({
+test("drag-based moves should transfer existing focus to new square", async ({
   page,
 }) => {
   // tab into board; a1 should have focus

--- a/tests/focus-handling.spec.ts
+++ b/tests/focus-handling.spec.ts
@@ -1,0 +1,27 @@
+import { test } from "@playwright/test";
+import { squareLocator, tabIntoBoard, expectHasFocus } from "./helpers";
+
+test.beforeEach(async ({ page }) => {
+  await page.goto("/");
+});
+
+test("focus transfers to square only after mouse up", async ({ page }) => {
+  // tab into board
+  await tabIntoBoard(page);
+  await expectHasFocus(page, "a1");
+
+  // mouse down on square
+  const fromRect = await squareLocator(page, "d2").boundingBox();
+  if (fromRect !== null) {
+    await page.mouse.move(
+      fromRect.x + fromRect.width / 2,
+      fromRect.y + fromRect.height / 2
+    );
+  }
+  await page.mouse.down();
+  await expectHasFocus(page, "a1");
+
+  // focus should transfer after mouseup
+  await page.mouse.up();
+  await expectHasFocus(page, "d2");
+});

--- a/tests/tap-moves.spec.ts
+++ b/tests/tap-moves.spec.ts
@@ -1,0 +1,27 @@
+import { test, devices } from "@playwright/test";
+import { expectHasPiece, expectIsActive, squareLocator } from "./helpers";
+
+test.beforeEach(async ({ page }) => {
+  await page.goto("/");
+});
+
+test.use({ ...devices["Pixel 5"] });
+test("two-tap moves work correctly", async ({ page }) => {
+  // tap on first square
+  await squareLocator(page, "c2").tap();
+
+  // square should be marked as start square, and we should
+  // now be waiting for second touch
+  await expectIsActive(page, "c2", true);
+
+  // tap on second square
+  await squareLocator(page, "c4").tap();
+
+  // second square should be marked with a piece on it
+  await expectHasPiece(page, "c4", true);
+
+  // first square should no longer have move class or piece class on it,
+  // and we should be re-awaiting input
+  await expectHasPiece(page, "c2", false);
+  await expectIsActive(page, "c2", false);
+});


### PR DESCRIPTION
Fixes #20.

Code was arranged so that move "ending" logic would be happening in the
click handler only. However, in some cases (on mobile) a click event
won't be fired, mostly after a drag is started.

To work around this, this code duplicates click handling logic to
`pointerup`, and adds a flag that prevents re-handling that event in
the `click` handler.
