### PR TITLE
Add .js extensions to all imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Add full ".js" extension to all imports, per https://justinfagnani.com/2019/11/01/how-to-publish-web-components-to-npm/
+
 ## [1.0.0] - 2022-12-03
 
 - Release 1.0.0

--- a/src/GChessBoardElement.ts
+++ b/src/GChessBoardElement.ts
@@ -6,17 +6,17 @@ import {
   Side,
   Square,
   Piece,
-} from "./utils/chess";
-import { Board } from "./components/Board";
+} from "./utils/chess.js";
+import { Board } from "./components/Board.js";
 import importedStyles from "./style.css";
-import { assertUnreachable } from "./utils/typing";
-import { makeHTMLElement } from "./utils/dom";
+import { assertUnreachable } from "./utils/typing.js";
+import { makeHTMLElement } from "./utils/dom.js";
 import {
   Coordinates,
   CoordinatesPlacement,
   isCoordinatesPlacement,
-} from "./components/Coordinates";
-import { Arrows, BoardArrow } from "./components/Arrows";
+} from "./components/Coordinates.js";
+import { Arrows, BoardArrow } from "./components/Arrows.js";
 
 /**
  * A component that displays a chess board, with optional interactivity. Allows

--- a/src/components/Arrows.ts
+++ b/src/components/Arrows.ts
@@ -1,5 +1,5 @@
-import { getVisualRowColumn, Side, Square } from "../utils/chess";
-import { makeSVGElement } from "../utils/dom";
+import { getVisualRowColumn, Side, Square } from "../utils/chess.js";
+import { makeSVGElement } from "../utils/dom.js";
 
 type BoardArrowWeight = "normal" | "light" | "bold";
 

--- a/src/components/Board.ts
+++ b/src/components/Board.ts
@@ -9,11 +9,11 @@ import {
   Square,
   keyIsSquare,
   Piece,
-} from "../utils/chess";
-import { makeHTMLElement } from "../utils/dom";
-import { BoardState } from "./BoardState";
-import { assertUnreachable } from "../utils/typing";
-import { BoardSquare } from "./BoardSquare";
+} from "../utils/chess.js";
+import { makeHTMLElement } from "../utils/dom.js";
+import { BoardState } from "./BoardState.js";
+import { assertUnreachable } from "../utils/typing.js";
+import { BoardSquare } from "./BoardSquare.js";
 
 export class Board {
   private readonly _table: HTMLElement;

--- a/src/components/BoardPiece.ts
+++ b/src/components/BoardPiece.ts
@@ -1,6 +1,6 @@
-import { Piece, PieceType, Side } from "../utils/chess";
-import { makeHTMLElement } from "../utils/dom";
-import { assertUnreachable } from "../utils/typing";
+import { Piece, PieceType, Side } from "../utils/chess.js";
+import { makeHTMLElement } from "../utils/dom.js";
+import { assertUnreachable } from "../utils/typing.js";
 
 export type BoardPieceConfig = {
   /**

--- a/src/components/BoardSquare.ts
+++ b/src/components/BoardSquare.ts
@@ -1,5 +1,5 @@
-import { getSquareColor, Piece, pieceEqual, Square } from "../utils/chess";
-import { makeHTMLElement } from "../utils/dom";
+import { getSquareColor, Piece, pieceEqual, Square } from "../utils/chess.js";
+import { makeHTMLElement } from "../utils/dom.js";
 import {
   BoardPiece,
   ExplicitPiecePosition,

--- a/src/components/BoardState.ts
+++ b/src/components/BoardState.ts
@@ -1,4 +1,4 @@
-import { Square } from "../utils/chess";
+import { Square } from "../utils/chess.js";
 
 export type BoardState =
   | {

--- a/src/components/Coordinates.ts
+++ b/src/components/Coordinates.ts
@@ -1,5 +1,5 @@
-import { Side } from "../utils/chess";
-import { makeHTMLElement } from "../utils/dom";
+import { Side } from "../utils/chess.js";
+import { makeHTMLElement } from "../utils/dom.js";
 
 const COORDINATES_PLACEMENTS = ["inside", "outside", "hidden"] as const;
 export type CoordinatesPlacement = typeof COORDINATES_PLACEMENTS[number];

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,10 +4,10 @@ import {
   MoveEndEvent,
   MoveFinishedEvent,
   MoveCancelEvent,
-} from "./GChessBoardElement";
-import { Piece, PieceType, Position, Side, Square } from "./utils/chess";
-import { BoardArrow } from "./components/Arrows";
-import { CoordinatesPlacement } from "./components/Coordinates";
+} from "./GChessBoardElement.js";
+import { Piece, PieceType, Position, Side, Square } from "./utils/chess.js";
+import { BoardArrow } from "./components/Arrows.js";
+import { CoordinatesPlacement } from "./components/Coordinates.js";
 
 export { GChessBoardElement };
 export type {


### PR DESCRIPTION
This is a recommended tip in https://justinfagnani.com/2019/11/01/how-to-publish-web-components-to-npm/

"Always include file extensions in import specifiers"