### PR TITLE
Disable browser touch actions on moveable squares

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Reduce the number of squares where browser touch actions like scrolling
+  are disabled.
+
 ## [1.2.0] - 2023-12-22
 
 - Fix misalignment of arrows with board when `coords` is set to `outside`.

--- a/src/style.css
+++ b/src/style.css
@@ -80,7 +80,6 @@
 
   /* Prevent native dragging caused if any of the children are "selected". */
   user-select: none;
-  touch-action: none;
 }
 
 .board > tr > td {
@@ -114,6 +113,11 @@
     var(--p-move-target-marker-color) var(--move-target-marker-radius),
     var(--p-square-color) calc(var(--move-target-marker-radius) + 1px)
   );
+}
+
+[data-square]:is(.moveable) {
+  /* Disable default touch actions like drag if square has a moveable piece. */
+  touch-action: none;
 }
 
 [data-square].has-piece.marked-target,


### PR DESCRIPTION
Earlier, the whole board had `touch-action: none` set. This was too aggressive, and prevented scroll when the board covered the whole width of the screen. This was pointed out in #51.
 
This commit moves the `touch-action: none` to squares with `.moveable` class, as those are the only ones that would support a drag action (where we wouldn't want the browser interfering).

Fixes #51.