### PR TITLE
Support for custom pieces and css styles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ dist
 
 # other
 .DS_Store
+/.idea
 
 # testing
 test-results/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Move back to using Vite, as the reason to move to Rollup was to use things like
   `rollup-plugin-dts`. Now we have `vite-plugin-dts` which achieves the same thing.
+- Add support for custom pieces via `GChessBoardElement.addCustomPieces`.
+  Contributor: @lukedawilson
 
 ## [1.3.1] - 2024-07-14
 

--- a/src/components/BoardPiece.ts
+++ b/src/components/BoardPiece.ts
@@ -1,4 +1,9 @@
-import { Piece, PieceType, Side } from "../utils/chess.js";
+import {
+  Piece,
+  PieceType,
+  Side,
+  REVERSE_FEN_PIECE_TYPE_MAP,
+} from "../utils/chess.js";
 import { makeHTMLElement } from "../utils/dom.js";
 import { assertUnreachable } from "../utils/typing.js";
 
@@ -77,7 +82,7 @@ export class BoardPiece {
   /**
    * Map of piece to background image CSS class name.
    */
-  private static PIECE_CLASS_MAP: Record<Side, Record<PieceType, string>> = {
+  public static PIECE_CLASS_MAP: Record<Side, Record<PieceType, string>> = {
     white: {
       queen: "wq",
       king: "wk",
@@ -97,10 +102,21 @@ export class BoardPiece {
   };
 
   /**
-   * CSS custom property for scale applied to piece while draggging.
+   * CSS custom property for scale applied to piece while dragging.
    * This is overridden per input method within CSS styles.
    */
   private static PIECE_DRAG_SCALE_PROP = "--p-piece-drag-scale";
+
+  private resolvePieceClass(color: Side, pieceType: PieceType) {
+    const pieceClass = BoardPiece.PIECE_CLASS_MAP[color][pieceType];
+    if (pieceClass) {
+      return pieceClass;
+    }
+
+    const c = color === "white" ? "w" : "b";
+    const p = REVERSE_FEN_PIECE_TYPE_MAP[pieceType];
+    return `${c}${p}`;
+  }
 
   constructor(container: HTMLElement, config: BoardPieceConfig) {
     this.piece = config.piece;
@@ -109,13 +125,11 @@ export class BoardPiece {
       attributes: {
         role: "presentation",
         "aria-hidden": "true",
-        part: `piece-${
-          BoardPiece.PIECE_CLASS_MAP[this.piece.color][this.piece.pieceType]
-        }`,
+        part: `piece-${this.resolvePieceClass(this.piece.color, this.piece.pieceType)}`,
       },
       classes: [
         "piece",
-        BoardPiece.PIECE_CLASS_MAP[this.piece.color][this.piece.pieceType],
+        this.resolvePieceClass(this.piece.color, this.piece.pieceType),
       ],
     });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,11 +5,21 @@ import {
   MoveFinishedEvent,
   MoveCancelEvent,
 } from "./GChessBoardElement.js";
-import { Piece, PieceType, Position, Side, Square } from "./utils/chess.js";
+import {
+  Piece,
+  PieceType,
+  Position,
+  Side,
+  Square,
+  getPosition,
+  getFen,
+  addCustomPieceTypes,
+} from "./utils/chess.js";
 import { BoardArrow } from "./components/Arrows.js";
 import { CoordinatesPlacement } from "./components/Coordinates.js";
 
-export { GChessBoardElement };
+export { GChessBoardElement, getPosition, getFen, addCustomPieceTypes };
+
 export type {
   BoardArrow,
   CoordinatesPlacement,

--- a/src/utils/chess.ts
+++ b/src/utils/chess.ts
@@ -15,7 +15,7 @@ export const PIECE_TYPES = [
   "bishop",
   "rook",
   "pawn",
-] as const;
+];
 
 export type SquareColor = (typeof SQUARE_COLORS)[number];
 export type Side = (typeof SIDE_COLORS)[number];
@@ -76,15 +76,57 @@ const FEN_PIECE_TYPE_MAP: { [key: string]: PieceType } = {
   q: "queen",
   k: "king",
 };
-const REVERSE_FEN_PIECE_TYPE_MAP: Record<PieceType, string> = Object.keys(
-  FEN_PIECE_TYPE_MAP
-).reduce(
-  (acc, key) => {
-    acc[FEN_PIECE_TYPE_MAP[key]] = key;
-    return acc;
-  },
-  {} as Record<PieceType, string>
-);
+export const REVERSE_FEN_PIECE_TYPE_MAP: Record<PieceType, string> =
+  Object.keys(FEN_PIECE_TYPE_MAP).reduce(
+    (acc, key) => {
+      acc[FEN_PIECE_TYPE_MAP[key]] = key;
+      return acc;
+    },
+    {} as Record<PieceType, string>
+  );
+
+/**
+ * Add custom pieces to the board. These do not replace the default pieces, register custom piece types along with FEN notation codes.
+ * @param map Piece definitions in the following format:
+ *
+ * ```js
+ * {
+ *   a: 'amazon',
+ *   c: 'commoner',
+ *   e: 'elephant',
+ * }
+ * ```
+ *
+ * The key corresponds to the piece type in the FEN notation, such as `a` for `Amazon`.
+ *
+ * The following example FEN is taken from the variant [Maharajah and the Sepoys](https://en.wikipedia.org/wiki/Maharajah_and_the_Sepoys),
+ * and features a white custom Amazon piece, represented here by an `M` in the FEN string:
+ *
+ * ```
+ * rnbqkbnr/pppppppp/8/8/8/8/8/4M3
+ * ```
+ *
+ * The following example features a number of black custom pieces, including Centaur (h), Knibis (a), Kniroo (l) and Silver (y):
+ *
+ * ```
+ * lhaykahl/8/pppppppp/8/8/8/PPPPPPPP/RNBQKBNR
+ * ```
+ */
+export function addCustomPieceTypes(map: Record<string, string>): void {
+  Object.values(map).forEach((value) => PIECE_TYPES.push(value));
+
+  Object.assign(FEN_PIECE_TYPE_MAP, map);
+  Object.assign(
+    REVERSE_FEN_PIECE_TYPE_MAP,
+    Object.keys(FEN_PIECE_TYPE_MAP).reduce(
+      (acc, key) => {
+        acc[FEN_PIECE_TYPE_MAP[key]] = key;
+        return acc;
+      },
+      {} as Record<PieceType, string>
+    )
+  );
+}
 
 export type PositionDiff = {
   added: Array<{ piece: Piece; square: Square }>;


### PR DESCRIPTION
# Overview

This PR introduces two new features:

* Support for custom pieces
* Support for adding custom CSS styles

## Custom pieces

The PR introduces a new method to `GChessBoardElement`, `addCustomPieces`. The new custom pieces do not replace the default pieces, but add to them.

Piece definitions are specified in the following format:
```javascript
{
  a: { name: 'amazon', b: '<svg>...</svg>', w: '<svg>...</svg>' },
  c: { name: 'commoner', b: '<svg>...</svg>', w: '<svg>...</svg>' },
  e: { name: 'elephant', b: '<svg>...</svg>', w: '<svg>...</svg>' },
}
```

The key corresponds to the piece type in the FEN notation, such as `a` for `Amazon`. `b` and `w` are raw SVG strings for the black and white pieces, respectively.

## Custom CSS styles

The PR introduces a second new method to `GChessBoardElement`, `addStyles`. This takes a literal css string, which is appended to the bottom of the css stylesheet, giving it precedence and thus allowing for style overrides.

For example:

```typescript
myGCessBoardElement.addStyles(`
  :host {
    --square-color-dark: #60a3d9;
    --square-color-light: #dbe9f5;

    --square-color-dark-hover: #4e8fc5;
    --square-color-light-hover: #cfe0ef;

    --square-color-dark-active: #3c7eb4;
    --square-color-light-active: #bfd7ed;

    --outline-color-dark-active: #2b6ca1;
    --outline-color-light-active: #91c2ea;

    --outline-color-focus: #5f8ec6;

    --move-target-marker-color-dark-square: hsl(144deg 64% 9% / 90%);
    --move-target-marker-color-light-square: hsl(144deg 64% 9% / 90%);

    --arrow-color-primary: #0074b7;
    --arrow-color-secondary: #60a3d9;
  }
`);
```
