### PR TITLE
Support for custom pieces as properties of GChessBoardElement instance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ dist
 
 # other
 .DS_Store
+/.idea
 
 # testing
 test-results/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Move back to using Vite, as the reason to move to Rollup was to use things like
   `rollup-plugin-dts`. Now we have `vite-plugin-dts` which achieves the same thing.
+- Add support for custom pieces via `GChessBoardElement.addCustomPieces`.
+  Contributor: @lukedawilson
 
 ## [1.3.1] - 2024-07-14
 

--- a/src/components/BoardPiece.ts
+++ b/src/components/BoardPiece.ts
@@ -1,4 +1,9 @@
-import { Piece, PieceType, Side } from "../utils/chess.js";
+import {
+  Piece,
+  PieceType,
+  Side,
+  REVERSE_FEN_PIECE_TYPE_MAP,
+} from "../utils/chess.js";
 import { makeHTMLElement } from "../utils/dom.js";
 import { assertUnreachable } from "../utils/typing.js";
 
@@ -77,7 +82,7 @@ export class BoardPiece {
   /**
    * Map of piece to background image CSS class name.
    */
-  private static PIECE_CLASS_MAP: Record<Side, Record<PieceType, string>> = {
+  public static PIECE_CLASS_MAP: Record<Side, Record<PieceType, string>> = {
     white: {
       queen: "wq",
       king: "wk",
@@ -97,10 +102,21 @@ export class BoardPiece {
   };
 
   /**
-   * CSS custom property for scale applied to piece while draggging.
+   * CSS custom property for scale applied to piece while dragging.
    * This is overridden per input method within CSS styles.
    */
   private static PIECE_DRAG_SCALE_PROP = "--p-piece-drag-scale";
+
+  private resolvePieceClass(color: Side, pieceType: PieceType) {
+    const pieceClass = BoardPiece.PIECE_CLASS_MAP[color][pieceType];
+    if (pieceClass) {
+      return pieceClass;
+    }
+
+    const c = color === "white" ? "w" : "b";
+    const p = REVERSE_FEN_PIECE_TYPE_MAP[pieceType];
+    return `${c}${p}`;
+  }
 
   constructor(container: HTMLElement, config: BoardPieceConfig) {
     this.piece = config.piece;
@@ -109,13 +125,11 @@ export class BoardPiece {
       attributes: {
         role: "presentation",
         "aria-hidden": "true",
-        part: `piece-${
-          BoardPiece.PIECE_CLASS_MAP[this.piece.color][this.piece.pieceType]
-        }`,
+        part: `piece-${this.resolvePieceClass(this.piece.color, this.piece.pieceType)}`,
       },
       classes: [
         "piece",
-        BoardPiece.PIECE_CLASS_MAP[this.piece.color][this.piece.pieceType],
+        this.resolvePieceClass(this.piece.color, this.piece.pieceType),
       ],
     });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,12 +13,11 @@ import {
   Square,
   getPosition,
   getFen,
-  addCustomPieceTypes,
 } from "./utils/chess.js";
 import { BoardArrow } from "./components/Arrows.js";
 import { CoordinatesPlacement } from "./components/Coordinates.js";
 
-export { GChessBoardElement, getPosition, getFen, addCustomPieceTypes };
+export { GChessBoardElement, getPosition, getFen };
 
 export type {
   BoardArrow,

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,11 +5,21 @@ import {
   MoveFinishedEvent,
   MoveCancelEvent,
 } from "./GChessBoardElement.js";
-import { Piece, PieceType, Position, Side, Square } from "./utils/chess.js";
+import {
+  Piece,
+  PieceType,
+  Position,
+  Side,
+  Square,
+  getPosition,
+  getFen,
+  addCustomPieceTypes,
+} from "./utils/chess.js";
 import { BoardArrow } from "./components/Arrows.js";
 import { CoordinatesPlacement } from "./components/Coordinates.js";
 
-export { GChessBoardElement };
+export { GChessBoardElement, getPosition, getFen, addCustomPieceTypes };
+
 export type {
   BoardArrow,
   CoordinatesPlacement,

--- a/src/utils/chess.ts
+++ b/src/utils/chess.ts
@@ -15,7 +15,7 @@ export const PIECE_TYPES = [
   "bishop",
   "rook",
   "pawn",
-] as const;
+];
 
 export type SquareColor = (typeof SQUARE_COLORS)[number];
 export type Side = (typeof SIDE_COLORS)[number];
@@ -76,15 +76,57 @@ const FEN_PIECE_TYPE_MAP: { [key: string]: PieceType } = {
   q: "queen",
   k: "king",
 };
-const REVERSE_FEN_PIECE_TYPE_MAP: Record<PieceType, string> = Object.keys(
-  FEN_PIECE_TYPE_MAP
-).reduce(
-  (acc, key) => {
-    acc[FEN_PIECE_TYPE_MAP[key]] = key;
-    return acc;
-  },
-  {} as Record<PieceType, string>
-);
+export const REVERSE_FEN_PIECE_TYPE_MAP: Record<PieceType, string> =
+  Object.keys(FEN_PIECE_TYPE_MAP).reduce(
+    (acc, key) => {
+      acc[FEN_PIECE_TYPE_MAP[key]] = key;
+      return acc;
+    },
+    {} as Record<PieceType, string>
+  );
+
+/**
+ * Add custom pieces to the board. These do not replace the default pieces, register custom piece types along with FEN notation codes.
+ * @param map Piece definitions in the following format:
+ *
+ * ```js
+ * {
+ *   a: 'amazon',
+ *   c: 'commoner',
+ *   e: 'elephant',
+ * }
+ * ```
+ *
+ * The key corresponds to the piece type in the FEN notation, such as `a` for `Amazon`.
+ *
+ * The following example FEN is taken from the variant [Maharajah and the Sepoys](https://en.wikipedia.org/wiki/Maharajah_and_the_Sepoys),
+ * and features a white custom Amazon piece, represented here by an `M` in the FEN string:
+ *
+ * ```
+ * rnbqkbnr/pppppppp/8/8/8/8/8/4M3
+ * ```
+ *
+ * The following example features a number of black custom pieces, including Centaur (h), Knibis (a), Kniroo (l) and Silver (y):
+ *
+ * ```
+ * lhaykahl/8/pppppppp/8/8/8/PPPPPPPP/RNBQKBNR
+ * ```
+ */
+export function addCustomPieceTypes(map: Record<string, string>): void {
+  Object.values(map).forEach((value) => PIECE_TYPES.push(value));
+
+  Object.assign(FEN_PIECE_TYPE_MAP, map);
+  Object.assign(
+    REVERSE_FEN_PIECE_TYPE_MAP,
+    Object.keys(FEN_PIECE_TYPE_MAP).reduce(
+      (acc, key) => {
+        acc[FEN_PIECE_TYPE_MAP[key]] = key;
+        return acc;
+      },
+      {} as Record<PieceType, string>
+    )
+  );
+}
 
 export type PositionDiff = {
   added: Array<{ piece: Piece; square: Square }>;


### PR DESCRIPTION
An implementation of https://github.com/mganjoo/gchessboard/pull/63 with the custom pieces being a property of the `GChessBoardElement` instance. Takes a `CustomPieceType` type which defaults to `never`. This type is passed everywhere it's needed.